### PR TITLE
Fix Cloudflare R2 binding and verify Astro output config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import cloudflare from '@astrojs/cloudflare';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-  output: 'static',
+  output: 'static', // In Astro v5, this is the default and supports SSR via `prerender = false`
   adapter: cloudflare({
     platformProxy: {
       enabled: true,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,13 +13,13 @@
     "binding": "ASSETS"
   },
   // TODO: uncomment once API token has R2 Storage: Edit permission
-  // "r2_buckets": [
-  //   {
-  //     "binding": "R2_BUCKET",
-  //     "bucket_name": "cubatattoostudio",
-  //     "preview_bucket_name": "cubatattoostudio"
-  //   }
-  // ],
+  "r2_buckets": [
+    {
+      "binding": "R2_BUCKET",
+      "bucket_name": "cubatattoostudio",
+      "preview_bucket_name": "cubatattoostudio"
+    }
+  ],
   "vars": {
     "UPLOAD_SECRET": ""
   }


### PR DESCRIPTION
This change enables the R2 bucket binding in `wrangler.jsonc`, which is required for the dynamic image API routes (`src/pages/api/images/`) to function correctly on Cloudflare.

It also verifies and documents that `output: 'static'` in `astro.config.mjs` is the correct configuration for Astro v5 when using the Cloudflare adapter with `prerender = false` routes (hybrid rendering). The previous `output: 'hybrid'` option has been removed in Astro v5.

Verified by running `npm run build` and checking for the generation of `dist/_worker.js`.

---
*PR created automatically by Jules for task [7402799649944138048](https://jules.google.com/task/7402799649944138048) started by @terrerovgh*