### PR TITLE
Fix CI failure: Disable D1 binding until valid ID is provided

### DIFF
--- a/src/data/instagram.ts
+++ b/src/data/instagram.ts
@@ -875,7 +875,7 @@ const instagramData: InstagramData = {
       ]
     }
   },
-  "lastFetched": "2026-02-16T01:58:45.680Z"
+  "lastFetched": "2026-02-16T02:20:26.445Z"
 };
 
 export default instagramData;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,13 +19,13 @@
       "preview_bucket_name": "cubatattoostudio"
     }
   ],
-  "d1_databases": [
-    {
-      "binding": "DB",
-      "database_name": "cubatattoostudio-db",
-      "database_id": "YOUR_DATABASE_ID_HERE"
-    }
-  ],
+  // "d1_databases": [
+  //   {
+  //     "binding": "DB",
+  //     "database_name": "cubatattoostudio-db",
+  //     "database_id": "YOUR_DATABASE_ID_HERE"
+  //   }
+  // ],
   "vars": {
     "SITE_URL": "https://cubatattoostudio.com"
   }


### PR DESCRIPTION
- Commented out D1 binding in wrangler.jsonc because the placeholder ID 'YOUR_DATABASE_ID_HERE' causes Cloudflare build/deployment failures.
- User must uncomment this section and provide a valid 'database_id' to enable the database connection.
- R2 binding remains enabled.